### PR TITLE
feat: neo4j Bolt TLS support (#2100)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ project.ext.externalDependency = [
     'mockito': 'org.mockito:mockito-core:3.0.0',
     'mysqlConnector': 'mysql:mysql-connector-java:5.1.47',
     'neo4jHarness': 'org.neo4j.test:neo4j-harness:3.4.11',
-    'neo4jJavaDriver': 'org.neo4j.driver:neo4j-java-driver:4.0.0',
+    'neo4jJavaDriver': 'org.neo4j.driver:neo4j-java-driver:4.0.1',
     'parseqTest': 'com.linkedin.parseq:parseq:3.0.7:test',
     'picocli': 'info.picocli:picocli:4.5.0',
     'playDocs': 'com.typesafe.play:play-docs_2.11:2.6.18',

--- a/gms/impl/build.gradle
+++ b/gms/impl/build.gradle
@@ -15,6 +15,7 @@ dependencies {
   compile externalDependency.gmaNeo4jDao
   compile externalDependency.gmaRestliResources
   compile externalDependency.gmaRestliResourcesDataTemplate
+  compile externalDependency.neo4jJavaDriver
 
   compileOnly externalDependency.lombok
 


### PR DESCRIPTION
    Bumping version of neo4j-java-driver to include encryption support that came in 4.0.1.
    Also neeed to compile neo4j-java-driver in gms as well to include it in the WAR.



## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
