### PR TITLE
feat: neo4j https support (#2101)

### DIFF
--- a/docker/datahub-gms/start.sh
+++ b/docker/datahub-gms/start.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Add default URI (http) scheme if needed
-if [[ "$NEO4J_HOST" != *"://"* ]]; then
+if ! echo $NEO4J_HOST | grep -q "://" ; then
     NEO4J_HOST="http://$NEO4J_HOST"
 fi
 

--- a/docker/datahub-mae-consumer/start.sh
+++ b/docker/datahub-mae-consumer/start.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Add default URI (http) scheme if needed
-if [[ "$NEO4J_HOST" != *"://"* ]]; then
+if ! echo $NEO4J_HOST | grep -q "://" ; then
     NEO4J_HOST="http://$NEO4J_HOST"
 fi
 


### PR DESCRIPTION
Fixed start script. The shell-syntax was not supported by the docker image.



## Checklist
- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [X] Links to related issues (if applicable)
- [X] Tests for the changes have been added/updated (if applicable)
- [X] Docs related to the changes have been added/updated (if applicable)
