### PR TITLE
fix: enable github ci-builds on the k_release_* branches

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -3,12 +3,14 @@ on:
   push:
     branches:
       - master
+      - k_release_*
     paths-ignore:
       - 'docs/**'
       - '**.md'
   pull_request:
     branches:
       - master
+      - k_release_*
     paths-ignore:
       - 'docs/**'
       - '**.md'
@@ -26,10 +28,10 @@ jobs:
           java-version: 1.8
       - name: Gradle build (and test)
         run: ./gradlew build
-      - name: Slack failure notification
-        if: failure() && github.event_name == 'push'
-        uses: kpritam/slack-job-status-action@v1
-        with:
-          job-status: ${{ job.status }}
-          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
-          channel: github-activities
+#      - name: Slack failure notification
+#        if: failure() && github.event_name == 'push'
+#        uses: kpritam/slack-job-status-action@v1
+#        with:
+#          job-status: ${{ job.status }}
+#          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+#          channel: github-activities


### PR DESCRIPTION

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
