### PR TITLE
fix(ui): show display name instead of name for owning groups (#3909)

### DIFF
--- a/datahub-web-react/src/app/shared/avatar/AvatarsGroup.tsx
+++ b/datahub-web-react/src/app/shared/avatar/AvatarsGroup.tsx
@@ -37,7 +37,7 @@ export default function AvatarsGroup({ owners, entityRegistry, maxCount = 6, siz
                         owner.owner.__typename === 'CorpGroup' && (
                             <CustomAvatar
                                 size={size || 28}
-                                name={owner.owner.name}
+                                name={entityRegistry.getDisplayName(EntityType.CorpGroup, owner.owner)}
                                 url={`/${entityRegistry.getPathName(owner.owner.type || EntityType.CorpGroup)}/${
                                     owner.owner.urn
                                 }`}

--- a/datahub-web-react/src/graphql/fragments.graphql
+++ b/datahub-web-react/src/graphql/fragments.graphql
@@ -43,6 +43,7 @@ fragment ownershipFields on Ownership {
                 type
                 name
                 info {
+                    displayName
                     email
                     admins {
                         urn


### PR DESCRIPTION

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
